### PR TITLE
Mitigation of CVE-2023-0361 vulnerability

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -118,5 +118,8 @@ RUN mkdir -p ${STORE_DIR} && chmod -R 777 ${STORE_DIR}
 # Set default run command
 CMD ["tini","run_orchestrator"]
 
+# needed to mitigate CVE-2023-0361
+RUN apt install libgnutls30>=3.7.1-5+deb11u3
+
 # Change to application user
 USER 2000


### PR DESCRIPTION
Detected as part of the DAST process in python:3.9-slim-bullseye, our base Docker image.

It updates the `libgnutls30` dependency.

[CVE-2023-0361](https://nvd.nist.gov/vuln/detail/CVE-2023-0361).